### PR TITLE
Connected view/src/StoredStateStore.tsx to patchConnection.

### DIFF
--- a/view/src/StoredStateStore.test.tsx
+++ b/view/src/StoredStateStore.test.tsx
@@ -1,0 +1,86 @@
+import { vi } from "vitest";
+import React from "react";
+import { render, act } from "@testing-library/react";
+
+// Declare mockPatch in outer scope so the mocked module can access the latest reference
+let mockPatch: any;
+
+vi.mock("./common/patchConnection", () => ({
+    getPatchConnection: () => mockPatch,
+}));
+
+import { StoredStateStoreProvider, useStoredStateStore } from "./StoredStateStore";
+
+// Helper component to drive updates
+const TestComponent: React.FC<{ onRender?: (api: any) => void }> = ({ onRender }) => {
+    const store = useStoredStateStore();
+    onRender?.(store);
+    return null;
+};
+
+describe("StoredStateStore patch integration", () => {
+    let listeners: Record<string, Function[]>;
+
+    beforeEach(() => {
+        listeners = {};
+        mockPatch = {
+            sendStoredStateValue: vi.fn(),
+            requestStoredStateValue: vi.fn(),
+            requestFullStoredState: vi.fn((cb) => {
+                // simulate async callback with empty state
+                setTimeout(() => cb({ values: {} }), 0);
+            }),
+            addStoredStateValueListener: vi.fn((fn) => {
+                (listeners["state_key_value"] ||= []).push(fn);
+            }),
+            removeStoredStateValueListener: vi.fn((fn) => {
+                listeners["state_key_value"] = (listeners["state_key_value"] || []).filter((l) => l !== fn);
+            }),
+            // utility to emit
+            emit(key: string, value: any) {
+                (listeners["state_key_value"] || []).forEach((l) => l({ key, value }));
+            },
+        };
+
+        // mock already registered above – just ensure module under test sees fresh mockPatch
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+        // Re-register mock after module reset (Vitest clears mocks); ensure StoredStateStore keeps working if re-imported.
+        vi.doMock("./common/patchConnection", () => ({
+            getPatchConnection: () => mockPatch,
+        }));
+    });
+
+    it("sends delta when updating local state", async () => {
+        let api: any;
+        render(
+            <StoredStateStoreProvider>
+                <TestComponent onRender={(a) => (api = a)} />
+            </StoredStateStoreProvider>
+        );
+
+        await act(async () => {
+            api.updateStoredStateItem("selectedInstrument")("snare1");
+        });
+
+        // should have sent stored state value for selectedInstrument
+        expect(mockPatch.sendStoredStateValue).toHaveBeenCalledWith("selectedInstrument", "snare1");
+    });
+
+    it("updates local state when patch emits change", async () => {
+        let api: any;
+        render(
+            <StoredStateStoreProvider>
+                <TestComponent onRender={(a) => (api = a)} />
+            </StoredStateStoreProvider>
+        );
+
+        await act(async () => {
+            mockPatch.emit("selectedInstrument", "snare2");
+        });
+
+        expect(api.storedState.selectedInstrument).toBe("snare2");
+    });
+});

--- a/view/src/StoredStateStore.tsx
+++ b/view/src/StoredStateStore.tsx
@@ -4,9 +4,9 @@
  * @todo: actually link to patchConnection
  */
 
-import React, { createContext, useState, useContext } from "react";
+import React, { createContext, useState, useContext, useEffect, useRef } from "react";
 import { InstrumentKey, instrumentKeys } from "./params";
-
+import { getPatchConnection } from "./common/patchConnection";
 export interface StoredState {
   selectedInstrument: InstrumentKey;
 }
@@ -37,9 +37,39 @@ export const StoredStateStoreProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
   const [state, setState] = useState<StoredState>(initialState);
+  // Keep a ref of last state so we can compare inside effects without stale closures
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  // Push a delta to the patch connection for each updated key
+  const sendStoredStateDelta = (delta: Partial<StoredState>) => {
+    const patchConnection = getPatchConnection();
+    if (!patchConnection) return;
+    for (const k in delta) {
+      const key = k as keyof StoredState;
+      const value = delta[key];
+      // Future-proof: allow null/undefined to clear
+      patchConnection.sendStoredStateValue?.(key, value as any);
+    }
+  };
 
   const setStoredState = (value: Partial<StoredState>) => {
-    setState((prevState) => ({ ...prevState, ...value }));
+    if (!value || Object.keys(value).length === 0) return;
+    setState((prevState) => {
+      const next = { ...prevState, ...value };
+      // Send only changed keys
+      const changed: Partial<StoredState> = {};
+      for (const k in value) {
+        const key = k as keyof StoredState;
+        if (prevState[key] !== next[key]) changed[key] = next[key];
+      }
+      if (Object.keys(changed).length) {
+        sendStoredStateDelta(changed);
+      }
+      return next;
+    });
   };
 
   const updateStoredStateItem: StoredStateUpdater = (key) => (value) =>
@@ -65,6 +95,53 @@ export const StoredStateStoreProvider: React.FC<{
       selectedInstrument: nextInstrument,
     });
   };
+
+  // Initial sync + listener registration
+  useEffect(() => {
+    const patchConnection = getPatchConnection();
+    if (!patchConnection) return; // running in tests or without host
+
+    // Listener for individual key updates from patch
+    const storedStateListener = ({ key, value }: { key: string; value: any }) => {
+      if (!(key in stateRef.current)) return; // ignore keys we don't know yet
+      const typedKey = key as keyof StoredState;
+      if (stateRef.current[typedKey] !== value) {
+        setState((prev) => ({ ...prev, [typedKey]: value }));
+      }
+    };
+
+    patchConnection.addStoredStateValueListener?.(storedStateListener);
+
+    // Request full state so we can merge existing values (if any) stored by host
+    patchConnection.requestFullStoredState?.((full: any) => {
+      try {
+        const values = full?.values || {};
+        const incoming: Partial<StoredState> = {};
+        for (const k in values) {
+          if (k in stateRef.current) {
+            incoming[k as keyof StoredState] = values[k];
+          }
+        }
+        if (Object.keys(incoming).length) {
+          setState((prev) => ({ ...prev, ...incoming }));
+        } else {
+          // If host has nothing, push our initial state so it becomes persisted
+          sendStoredStateDelta(stateRef.current);
+        }
+      } catch (_e) {
+        // noop - fail silently, not critical
+      }
+    });
+
+    // Also request each individual key to trigger callbacks (mirrors ParamStore pattern)
+    for (const key in stateRef.current) {
+      patchConnection.requestStoredStateValue?.(key);
+    }
+
+    return () => {
+      patchConnection.removeStoredStateValueListener?.(storedStateListener);
+    };
+  }, []);
 
   return (
     <StoredStateStoreContext.Provider


### PR DESCRIPTION
## 🎵 Summary of Changes

This PR adds **Cmajor stored state synchronization** for UI preferences, starting with the **selected instrument**.

Previously, only parameter values were persisted across plugin sessions in DAWs. With this PR, the **selected instrument is now saved and restored automatically**, allowing users to continue where they left off. The implementation is **future-friendly** additional UI state keys can be persisted with minimal effort.

---

## 🏷️ Type of Change

* [x] ✨ Feature enhancement
* [x] 🧪 Test improvements

---

## 💡 Motivation/Reason

Persisting only parameter data caused UI selections (like instrument choice) to reset every time a DAW session was reopened. This was frustrating and inconsistent with user expectations.

By syncing **StoredStateStore ↔ PatchConnection stored state**, we achieve **session continuity**, making the user experience more polished and professional.

---

## 🧪 Testing Done

* [x] ✅ All existing tests pass (`npm test`)
* [x] 🧪 Added `StoredStateStore.test.tsx` covering sync logic
* [x] 📨 Verified outbound delta sends via `sendStoredStateValue`
* [x] 🔄 Verified inbound updates via state_key_value listeners
* [x] 🚫 No breaking changes to existing functionality

---

## 🔗 Related Issues

Fixes #61

---

## 📝 Additional Notes

* Falls back gracefully when no `PatchConnection` is present (e.g., dev mode / tests)
* Silently ignores malformed full-state payloads to avoid breaking UX
* Registered listeners only apply updates when values actually change
* Internal `ref` avoids stale closure bugs in listener callbacks

---

## 📋 Checklist

* [x] 📖 I have read the contributing guidelines
* [x] 🌿 My code follows the project conventions
* [x] 💬 I have written clear commit messages
* [x] 🎯 This PR focuses on a single change



