### PR TITLE
Implement ElectricSnare sound design (Midi note 40)

### DIFF
--- a/dsp/Percupuff.cmajor
+++ b/dsp/Percupuff.cmajor
@@ -30,6 +30,7 @@ namespace Percupuff
             noise = std::noise::White;
             bassDrum = Drums::BassDrum;
             snare = Drums::Snare;
+            electricSnare = Drums::ElectricSnare;
             hihat = Drums::Hihat;
             clap = Drums::Clap;
             cowbell = Drums::Cowbell;
@@ -52,12 +53,14 @@ namespace Percupuff
             p.paramsOut -> cowbell.paramsIn;
             p.paramsOut -> hihat.paramsIn;
             p.paramsOut -> snare.paramsIn;
+            p.paramsOut -> electricSnare.paramsIn;
             p.paramsOut -> sideStick.paramsIn;
 
             // Send the midi events so the sound processors know when to start playing.
             midiIn -> mpe;
             mpe -> bassDrum.eventIn;
             mpe -> snare.eventIn;
+            mpe -> electricSnare.eventIn;
             mpe -> hihat.eventIn;
             mpe -> clap.eventIn;
             mpe -> cowbell.eventIn;
@@ -70,6 +73,7 @@ namespace Percupuff
             // Some sounds use noise.
             noise -> hihat.noiseIn;
             noise -> snare.noiseIn;
+            noise -> electricSnare.noiseIn;
             noise -> clap.noiseIn;
             noise -> crash.noiseIn;
             noise -> claves.noiseIn;
@@ -78,6 +82,7 @@ namespace Percupuff
             // it into the gain limiter to adjust how loud they are.
             bassDrum -> gainLimiter;
             snare -> gainLimiter;
+            electricSnare -> gainLimiter;
             hihat -> gainLimiter;
             clap -> gainLimiter;
             cowbell -> gainLimiter;

--- a/dsp/drums/ElectricSnare.cmajor
+++ b/dsp/drums/ElectricSnare.cmajor
@@ -1,0 +1,106 @@
+// https://www.soundonsound.com/techniques/synthesizing-drums-snare-drum
+
+namespace Percupuff
+{
+    namespace Drums
+    {
+        // This processor tries to create a realistic electric snare drum sound.
+        // Additive synthesis is used to create the initial impact of the snare,
+        // with filtered white noise mixed in for more brightness.
+        processor ElectricSnare {
+            input event (std::notes::NoteOn) eventIn;
+            input event Params paramsIn;
+            input stream float noiseIn;
+            output stream float<2> out;
+            
+            float triggerVelocity = 0.0f;
+            int midiNotePitch = 0;
+            float outputLevel = 0.5f;
+            float panning = 0.0f;
+
+            event paramsIn(Params p) {
+                midiNotePitch = int(p.snare2Midi);
+                outputLevel = p.snare2Level * 0.01f;
+                panning = p.snare2Panning;
+            }
+
+            event eventIn(std::notes::NoteOn n) {
+                if (int (n.pitch) == midiNotePitch) {
+                    triggerVelocity = sqrt(n.velocity);
+                }
+            }
+
+            node envelope = Envelope;
+            node osc = OscillatorBank(OscillatorShape::triangle);
+            
+            // Filters that shape the white noise.
+            // Use LpfResonant to add resonance for brightness
+            LpfResonant lowpass = (0.0f, 0.0f);
+            NotchFilter notch;
+
+            void main()
+            {
+                envelope.releaseIn <- .2f;
+                envelope.attackIn <- .005f;
+
+                osc.frequencyIn <- float<8>(
+                    276.0f,
+                    346.0f,
+                    387.0f,
+                    424.0f,
+                    540.0f,
+                    624.0f,
+                    730.0f,
+                    850.0f
+                );
+
+                osc.levelIn <- float<8>(
+                    0.9f,
+                    0.8f,
+                    0.9f,
+                    0.8f,
+                    0.7f,
+                    0.6f,
+                    0.7f,
+                    0.8f
+                );
+
+                let invSampleRate = 1.0f / float(processor.frequency);
+                notch.setCoefficients(20000.0f, 0.8f, float(processor.frequency));
+                
+                loop
+                {
+                    while (triggerVelocity == 0) {
+                        advance();
+                    }
+
+                    let vel = triggerVelocity;
+                    triggerVelocity = 0.0f;
+                    envelope.triggerIn <- void;
+                    envelope.advance();
+                    float gain = envelope.gainOut;
+
+                    while (gain > 0.0f && triggerVelocity == 0.0f) {
+                        osc.frequencyModIn <- gain * 0.02f;
+
+                        float lpSample = lowpass.getSample(noiseIn, 8000.0f + vel * 15000.0f, 0.7f, invSampleRate);
+                        lpSample = notch.getSample(lpSample);
+
+                        let outSample = ((sin(osc.out * (1.0f + vel * 0.9f)) + lpSample * 0.2f) * gain * (0.9f + vel * 0.4f)) * outputLevel;
+
+                        float pan = panning * 0.01f;
+                        float leftGain  = 0.5f * (1.0f - pan);
+                        float rightGain = 0.5f * (1.0f + pan);
+                        out <- (outSample * leftGain, outSample * rightGain);
+
+                        osc.advance();
+                        
+                        gain = envelope.gainOut;
+                        envelope.advance();
+                        advance();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/percupuff.cmajorpatch
+++ b/percupuff.cmajorpatch
@@ -20,6 +20,7 @@
     "dsp/Envelope.cmajor",
     "dsp/drums/BassDrum.cmajor",
     "dsp/drums/Snare.cmajor",
+    "dsp/drums/ElectricSnare.cmajor",
     "dsp/drums/Hihat.cmajor",
     "dsp/drums/Clap.cmajor",
     "dsp/drums/Cowbell.cmajor",


### PR DESCRIPTION
## 🎵 Summary of Changes
Added the ElectricSnare sound corresponding to "snare2" in `params.ts`. Mainly based on the acoustic snare`Snare.cmajor` with some changes:
- Use `LpfResonant` instead of `Lpf` as the low pass filter for a brighter tone
- changed `attackIn` on the envelope
- Update `frequencyIn` and `levelIn` for a higher frequency sound
- Changed notch frequency coefficient to be higher. 
- Slightly increase gain and tweaked the numbers in `lpSample` and `outSample`

## 🏷️ Type of Change
- [ ] 🐛 Bug fix
- [ ] 🥁 New drum sound/instrument 
- [ ] 🎚️ Improvement to existing sound/instrument 
- [ ] ✨ Feature enhancement
- [ ] 📖 Documentation update
- [ ] 🔧 Code refactoring
- [ ] 🧪 Test improvements
- [ ] 🎨 UI/View improvements

## 💡 Motivation/Reason
I wanted to complete the electric snare sound, since it's already in the UI but there's no sound for it. I haven't done a lot of sound design stuff, so I thought it would be fun to try something a little different for Hacktoberfest.

## 🧪 Testing Done
- [ ] 🏗️ Built view successfully (`npm run build`)
- [ ] 🎧 Tested with `Cmajor: Run patch` command
- [ ] ✅ No breaking changes to existing functionality
- [ ] 🔊 Audio output sounds correct (for audio changes)
- [ ] 📱 UI works as expected (for view changes)

## 🔗 Related Issues
Fixes #32 

## 📝 Additional Notes
I tried to replicate the snares in the following YouTube videos, mostly through trial and error.
https://www.youtube.com/watch?v=Fks15MXxwas
https://www.youtube.com/watch?v=NifOAvu7KQk

Video recording: 
(Oh gosh the audio quality is horrible from my computer mic, please run my branch for a more accurate sound)

https://github.com/user-attachments/assets/0d078f95-772a-4a58-b67c-3ab065b81637



## 📋 Checklist
- [ ] 📖 I have read the contributing guidelines
- [ ] 🌿 My code follows the project conventions
- [ ] 💬 I have written clear commit messages
- [ ] 🎯 This PR focuses on a single change