### PR TITLE
Implement DSP/Cmajor code for 'Cabasa' (Midi note 69)

### DIFF
--- a/dsp/Params.cmajor
+++ b/dsp/Params.cmajor
@@ -43,6 +43,10 @@ namespace Percupuff
         float crash1Midi;
         float crash2Midi;
         float crash3Midi;
+        float rideBellLevel;
+        float rideBellPanning;
+        float rideBellVelocity;
+        float rideBellMidi;
         float bongoLevel;
         float bongoPanning;
         float bongoVelocity;
@@ -82,10 +86,10 @@ namespace Percupuff
         float cowbellPanning;
         float cowbellVelocity;
         float cowbellMidi;
-        float rideBellLevel;
-        float rideBellPanning;
-        float rideBellVelocity;
-        float rideBellMidi;
+        float cabasaLevel;
+        float cabasaPanning;
+        float cabasaVelocity;
+        float cabasaMidi;
         float sideStickLevel;
         float sideStickPanning;
         float sideStickVelocity;
@@ -130,6 +134,10 @@ namespace Percupuff
         p.crash1Midi = 49.0f;
         p.crash2Midi = 57.0f;
         p.crash3Midi = 52.0f;
+        p.rideBellLevel = 50.0f;
+        p.rideBellPanning = 0.0f;
+        p.rideBellVelocity = 100.0f;
+        p.rideBellMidi = 53.0f;
         p.bongoLevel = 50.0f;
         p.bongoPanning = 0.0f;
         p.bongoVelocity = 100.0f;
@@ -169,10 +177,10 @@ namespace Percupuff
         p.cowbellPanning = 0.0f;
         p.cowbellVelocity = 100.0f;
         p.cowbellMidi = 56.0f;
-        p.rideBellLevel = 50.0f;
-        p.rideBellPanning = 0.0f;
-        p.rideBellVelocity = 100.0f;
-        p.rideBellMidi = 53.0f;
+        p.cabasaLevel = 50.0f;
+        p.cabasaPanning = 0.0f;
+        p.cabasaVelocity = 100.0f;
+        p.cabasaMidi = 69.0f;
         p.sideStickLevel = 50.0f;
         p.sideStickPanning = 0.0f;
         p.sideStickVelocity = 100.0f;
@@ -217,6 +225,10 @@ namespace Percupuff
         input event float crash1Midi [[ name: "crash1Midi", min: 0, max: 127, init: 49, step: 1 ]];
         input event float crash2Midi [[ name: "crash2Midi", min: 0, max: 127, init: 57, step: 1 ]];
         input event float crash3Midi [[ name: "crash3Midi", min: 0, max: 127, init: 52, step: 1 ]];
+        input event float rideBellLevel [[ name: "rideBellLevel", min: 0, max: 100, init: 50, step: 1 ]];
+        input event float rideBellPanning [[ name: "rideBellPanning", min: -100, max: 100, init: 0, step: 5 ]];
+        input event float rideBellVelocity [[ name: "rideBellVelocity", min: 0, max: 100, init: 100, step: 1 ]];
+        input event float rideBellMidi [[ name: "rideBellMidi", min: 0, max: 127, init: 53, step: 1 ]];
         input event float bongoLevel [[ name: "bongoLevel", min: 0, max: 100, init: 50, step: 1 ]];
         input event float bongoPanning [[ name: "bongoPanning", min: -100, max: 100, init: 0, step: 5 ]];
         input event float bongoVelocity [[ name: "bongoVelocity", min: 0, max: 100, init: 100, step: 1 ]];
@@ -256,10 +268,10 @@ namespace Percupuff
         input event float cowbellPanning [[ name: "cowbellPanning", min: -100, max: 100, init: 0, step: 5 ]];
         input event float cowbellVelocity [[ name: "cowbellVelocity", min: 0, max: 100, init: 100, step: 1 ]];
         input event float cowbellMidi [[ name: "cowbellMidi", min: 0, max: 127, init: 56, step: 1 ]];
-        input event float rideBellLevel [[ name: "rideBellLevel", min: 0, max: 100, init: 50, step: 1 ]];
-        input event float rideBellPanning [[ name: "rideBellPanning", min: -100, max: 100, init: 0, step: 5 ]];
-        input event float rideBellVelocity [[ name: "rideBellVelocity", min: 0, max: 100, init: 100, step: 1 ]];
-        input event float rideBellMidi [[ name: "rideBellMidi", min: 0, max: 127, init: 53, step: 1 ]];
+        input event float cabasaLevel [[ name: "cabasaLevel", min: 0, max: 100, init: 50, step: 1 ]];
+        input event float cabasaPanning [[ name: "cabasaPanning", min: -100, max: 100, init: 0, step: 5 ]];
+        input event float cabasaVelocity [[ name: "cabasaVelocity", min: 0, max: 100, init: 100, step: 1 ]];
+        input event float cabasaMidi [[ name: "cabasaMidi", min: 0, max: 127, init: 69, step: 1 ]];
         input event float sideStickLevel [[ name: "sideStickLevel", min: 0, max: 100, init: 50, step: 1 ]];
         input event float sideStickPanning [[ name: "sideStickPanning", min: -100, max: 100, init: 0, step: 5 ]];
         input event float sideStickVelocity [[ name: "sideStickVelocity", min: 0, max: 100, init: 100, step: 1 ]];
@@ -307,6 +319,10 @@ namespace Percupuff
         event crash1Midi (float f) { params.crash1Midi = f; update(); }
         event crash2Midi (float f) { params.crash2Midi = f; update(); }
         event crash3Midi (float f) { params.crash3Midi = f; update(); }
+        event rideBellLevel (float f) { params.rideBellLevel = f; update(); }
+        event rideBellPanning (float f) { params.rideBellPanning = f; update(); }
+        event rideBellVelocity (float f) { params.rideBellVelocity = f; update(); }
+        event rideBellMidi (float f) { params.rideBellMidi = f; update(); }
         event bongoLevel (float f) { params.bongoLevel = f; update(); }
         event bongoPanning (float f) { params.bongoPanning = f; update(); }
         event bongoVelocity (float f) { params.bongoVelocity = f; update(); }
@@ -346,10 +362,10 @@ namespace Percupuff
         event cowbellPanning (float f) { params.cowbellPanning = f; update(); }
         event cowbellVelocity (float f) { params.cowbellVelocity = f; update(); }
         event cowbellMidi (float f) { params.cowbellMidi = f; update(); }
-        event rideBellLevel (float f) { params.rideBellLevel = f; update(); }
-        event rideBellPanning (float f) { params.rideBellPanning = f; update(); }
-        event rideBellVelocity (float f) { params.rideBellVelocity = f; update(); }
-        event rideBellMidi (float f) { params.rideBellMidi = f; update(); }
+        event cabasaLevel (float f) { params.cabasaLevel = f; update(); }
+        event cabasaPanning (float f) { params.cabasaPanning = f; update(); }
+        event cabasaVelocity (float f) { params.cabasaVelocity = f; update(); }
+        event cabasaMidi (float f) { params.cabasaMidi = f; update(); }
         event sideStickLevel (float f) { params.sideStickLevel = f; update(); }
         event sideStickPanning (float f) { params.sideStickPanning = f; update(); }
         event sideStickVelocity (float f) { params.sideStickVelocity = f; update(); }

--- a/dsp/Percupuff.cmajor
+++ b/dsp/Percupuff.cmajor
@@ -39,6 +39,7 @@ namespace Percupuff
             bongos = Drums::Bongos;
             sideStick = Drums::SideStick;
             rideBell = Drums::RideBell;
+            cabasa = Drums::Cabasa;
             gainLimiter = std::levels::ConstantGain (float<2>, 1.0f);
             mpe = std::midi::MPEConverter;
         }
@@ -57,6 +58,7 @@ namespace Percupuff
             p.paramsOut -> electricSnare.paramsIn;
             p.paramsOut -> sideStick.paramsIn;
             p.paramsOut -> rideBell.paramsIn;
+            p.paramsOut -> cabasa.paramsIn;
 
             // Send the midi events so the sound processors know when to start playing.
             midiIn -> mpe;
@@ -71,6 +73,7 @@ namespace Percupuff
             mpe -> bongos.eventIn;
             mpe -> sideStick.eventIn;
             mpe -> rideBell.eventIn;
+            mpe -> cabasa.eventIn;
             mpe -> noteOn;
 
             // Some sounds use noise.
@@ -94,6 +97,7 @@ namespace Percupuff
             bongos -> gainLimiter;
             sideStick -> gainLimiter;
             rideBell -> gainLimiter;
+            cabasa -> gainLimiter;
 
             // Output the result.
             gainLimiter -> out;

--- a/dsp/drums/Cabasa.cmajor
+++ b/dsp/drums/Cabasa.cmajor
@@ -1,0 +1,105 @@
+namespace Percupuff
+{
+    namespace Drums
+    {
+        processor Cabasa {
+            input event (std::notes::NoteOn) eventIn;
+            output stream float<2> out;
+            input event Params paramsIn;
+
+            float triggerVelocity = 0.0f;
+            int midiNotePitch = 0;
+            float outputLevel = 0.5f;
+            float panning = 0.0f;
+
+            event paramsIn(Params p) {
+                midiNotePitch = int(p.cabasaMidi);
+                outputLevel = p.cabasaLevel * 0.01f;
+                panning = p.cabasaPanning;
+            }
+
+            event eventIn(std::notes::NoteOn n) {
+                if (int(n.pitch) == midiNotePitch)
+                    triggerVelocity = sqrt(n.velocity);
+            }
+
+            node envelope = Envelope;
+            node noise = std::noise::White;
+
+            // Use one resonant SVF, this gives the metallic "clack" sound
+            node filter = std::filters::tpt::svf::Processor(
+                std::filters::tpt::svf::Mode::bandPass, 4000.0f, 5.0f
+            );
+
+            void main()
+            {
+                envelope.attackIn <- 0.0008f;
+                let baseCutoff = 3800.0f; // Metallic "clack" frequency
+                let baseQ = 5.0f;        // This resonance is the "metal" sound
+
+                loop
+                {
+                    while (triggerVelocity == 0)
+                        advance();
+
+                    let baseVel = triggerVelocity;
+                    triggerVelocity = 0.0f;
+
+                    float burstCount   = 4 + (baseVel * 25);
+                    // Slightly increased spacing for a "heavier" bead sound
+                    float burstSpacing = 0.0005f + (1.0f - baseVel) * 0.0045f;
+
+                    for (int i = 0; i < int(burstCount); ++i)
+                    {
+                        float velJitter = 0.8f + (noise.out * 0.2f);
+                        float burstVel = baseVel * velJitter;
+
+                        // Modified release for more "body" on each bead hit
+                        envelope.releaseIn <- 0.004f + (noise.out * 0.001f); 
+                        envelope.triggerIn <- void;
+                        envelope.advance();
+
+                        float gain = envelope.gainOut;
+
+                        // Alternate stereo motion slightly
+                        float altPan = ((i % 2 == 0) ? -0.4f : 0.4f) + (panning * 0.01f);
+                        
+                        // Add jitter to cutoff and Q for a more natural, chaotic sound
+                        filter.frequency <- baseCutoff + (noise.out * 400.0f);
+                        filter.q <- baseQ + (noise.out * 0.5f);
+
+                        while (gain > 0.001f)
+                        {
+                            float raw = noise.out;
+
+                            // Run the noise through the filter
+                            filter.in <- raw;
+                            float filtered = filter.out;
+
+                            float outSample = filtered * gain * burstVel * outputLevel;
+
+                            float leftGain  = 0.5f * (1.0f - altPan);
+                            float rightGain = 0.5f * (1.0f + altPan);
+                            out <- (outSample * leftGain, outSample * rightGain);
+
+                            noise.advance();
+                            filter.advance();
+                            envelope.advance();
+                            advance();
+
+                            gain = envelope.gainOut;
+                        }
+
+                        float jitter = (noise.out * 0.0003f);
+                        int silentSamples = int((burstSpacing + jitter) * 44100.0f);
+                        for (int s = 0; s < silentSamples; ++s)
+                        {
+                            out <- (0.0f, 0.0f); // Output silence in stereo
+                            advance();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dsp/drums/Cabasa.cmajor
+++ b/dsp/drums/Cabasa.cmajor
@@ -91,7 +91,7 @@ namespace Percupuff
                         }
 
                         float jitter = (noise.out * 0.0003f);
-                        int silentSamples = int((burstSpacing + jitter) * 44100.0f);
+                        int silentSamples = int((burstSpacing + jitter) * float(processor.frequency));
                         for (int s = 0; s < silentSamples; ++s)
                         {
                             out <- (0.0f, 0.0f); // Output silence in stereo

--- a/percupuff.cmajorpatch
+++ b/percupuff.cmajorpatch
@@ -29,6 +29,7 @@
     "dsp/drums/Bongos.cmajor",
     "dsp/drums/SideStick.cmajor",
     "dsp/drums/RideBell.cmajor",
+    "dsp/drums/Cabasa.cmajor",
     "dsp/Percupuff.cmajor"
   ],
   "view": {

--- a/view/src/params.ts
+++ b/view/src/params.ts
@@ -34,6 +34,8 @@ export const instruments = {
 
   cowbell: { name: "Cowbell", group: "🐮", midi: 56 },
 
+  cabasa: { name: "Cabasa", group: null, midi: 69 },
+
   // Example of adding an instrument without having it show up in the UI yet.
   sideStick: { name: "Side Stick", group: null, midi: 37 },
 } as const;


### PR DESCRIPTION
## 🎵 Summary of Changes
This PR implements cmajor code for the Cabasa instrument. It takes a lot of inspiration from https://github.com/lilyvanoekel/percupuff/pull/80 , but I made the following changes:
- Replaced the butterworth highpass/lowpass filters with a single SVF (State Variable Filter), which allows us to control resonance (Q) to make it more "metallic"
- Adjusted the `burstSpacing` and `releaseIn` to more accurately reflect a cabasa.


## 🏷️ Type of Change
- [ ] 🐛 Bug fix
- [x] 🥁 New drum sound/instrument 
- [ ] 🎚️ Improvement to existing sound/instrument 
- [ ] ✨ Feature enhancement
- [ ] 📖 Documentation update
- [ ] 🔧 Code refactoring
- [ ] 🧪 Test improvements
- [ ] 🎨 UI/View improvements

## 💡 Motivation/Reason
I wanted to create a sound that is not drum-like this time. I also didn't know about the cabasa before, and it was fun to play around with different filters!

## 🧪 Testing Done
- [x] 🏗️ Built view successfully (`npm run build`)
- [x] 🎧 Tested with `Cmajor: Run patch` command
- [x] ✅ No breaking changes to existing functionality
- [x] 🔊 Audio output sounds correct (for audio changes)
- [x] 📱 UI works as expected (for view changes)

## 🔗 Related Issues
Fixes #42 

## 📝 Additional Notes
Any additional context, screenshots, or notes for reviewers


https://github.com/user-attachments/assets/a056feb9-edf4-44bc-83c0-02112ab2ffa9


## 📋 Checklist
- [x] 📖 I have read the contributing guidelines
- [x] 🌿 My code follows the project conventions
- [x] 💬 I have written clear commit messages
- [x] 🎯 This PR focuses on a single change